### PR TITLE
Bump commons-lang3 3.18.0 -> 3.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.19.0</version>
     </dependency>
     <dependency>
       <!-- Overwrite dependency introduced by opencsv 5.9 -->


### PR DESCRIPTION
Minor version bump. Brings the explicit dependency up to the highest version used in all of the derived dependencies (jena-arq).
Fixes #19