### PR TITLE
Override libthrift dependency to address CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project from 2026-05-11 onward will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.2-SNAPSHOT] - Unreleased
+
+### Security
+
+* Update transitive dependency on org.apache.thrift:libthrift to 0.23.0 to address CVE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 * Update transitive dependency on org.apache.thrift:libthrift to 0.23.0 to address CVE.
+
+## 4.0.1
+
+### Security
+
+* Update jackson-core 2.18.0 -> 2.18.6 to address CVEs
+
+## 4.0.0
+
+### Changed
+
+* Update to Jena 5.6.0. Updated to Jersey 3.x which will involve some namespace changes in downstream code that references the javax.ws.rs.* namespace. Updated OpenCSV to 5.12. NOTE that from this release a minimum Java version of Java 17 is required.
+
+## 3.1.7
+
+### Security
+
+* Override jackson versions used by jena 3.9.0 dependency to avoid severe CVEs. There are remaining CVEs logged against jena 3.9.0 but they are less severe and exploitable in our usage.
+
+## 3.1.6
+
+### Changed
+
+* Replaced Apache `commons-lang` by `commons-text` to avoid CVE-2025-48924 (though that wouldn't afffect our usage). Preferable over upgrading `commons-lang3` because the relevant module in `commons-lang3` is deprecated in favour of `commons-text`.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,4 @@ Support for geolocations including parsing/formating OS Grid References and conv
 
 ## Change log
 
-**4.0.1**
-
- * Update jackson-core 2.18.0 -> 2.18.6 to address CVEs
-
-**4.0.0** Update to Jena 5.6.0. Updated to Jersey 3.x which will involve some namespace changes in downstream code that references the javax.ws.rs.* namespace. Updated OpenCSV to 5.12. NOTE that from this release a minimum Java version of Java 17 is required.
-
-**3.1.7** Override jackson versions used by jena 3.9.0 dependency to avoid severe CVEs. There are remaining CVEs logged against jena 3.9.0 but they are less severe and exploitable in our usage.
-
-**3.1.6** Replaced Apache `commons-lang` by `commons-text` to avoid CVE-2025-48924 (though that wouldn't afffect our usage). Preferable over upgrading `commons-lang3` because the relevant module in `commons-lang3` is deprecated in favour of `commons-text`.
+Moved to CHANGELOG.md

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
     <dependency>
@@ -82,12 +86,18 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-          <version>5.12.2</version>
-          <scope>provided</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.23.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.12.2</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <!-- Jersey 3.x for Jakarta EE compatibility -->


### PR DESCRIPTION
Bump libthrift to 0.23.0 to address dependabot alert
Add a changelog file while I'm in there